### PR TITLE
Readme fix and Null Reference Exception

### DIFF
--- a/LeanKit.API.Client.Library/RestSharpCommandProcessor.cs
+++ b/LeanKit.API.Client.Library/RestSharpCommandProcessor.cs
@@ -267,7 +267,7 @@ namespace LeanKit.API.Client.Library
 				throw new LeanKitAPIException("A failure occurred retrieving the response from the API.");
 			}
 
-			if (response.ResponseUri.Host != requestedResource.Host)
+			if (response.ResponseUri != null && response.ResponseUri.Host != requestedResource.Host)
 			{
 				throw new InvalidAPIResourceException();
 			}

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Or, if more granular control of the proxy is required, it could look something l
 ```
 <system.net>
   <defaultProxy enabled="true" useDefaultCredentials="false">
-    <proxy usesystemdefaults="true" proxyaddress="http://192.168.1.10:3128" bypassonlocal="true" />
+    <proxy usesystemdefault="true" proxyaddress="http://192.168.1.10:3128" bypassonlocal="true" />
   </defaultProxy>
 </system.net>
 ```


### PR DESCRIPTION
…stemdefaults

Fixed Null Reference Exception in the RestSharpCommandProcessor - If there is a problem in the config or you set the account name to the full url instead of just the account name response.ResponseUri can be null